### PR TITLE
Add Dockerfile and usage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+CAs
+config
+tmp
+*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+# Install required packages
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        strongswan strongswan-pki pwgen openssh-client rsync \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy project files
+WORKDIR /app
+COPY . /app
+
+# Default entrypoint runs the Python CLI
+ENTRYPOINT ["python3", "central/scripts/kdc.py"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ python3 central/scripts/key_manager.py create myhost.example.com
 python3 central/scripts/key_manager.py info STORE/certs/myhost.example.com.pem
 ```
 
+## Docker
+
+A `Dockerfile` is provided to run the certificate management tools in a container.
+
+Build the image:
+
+```bash
+docker build -t kdc .
+```
+
+Run the CLI with persistent storage:
+
+```bash
+docker run --rm -it -v $(pwd)/data:/app/central/scripts/STORE kdc --help
+```
+
 ## Big thanks to
 
 - https://www.danballard.com/references/strongswan/www.zeitgeist.se/2013/11/22/strongswan-howto-create-your-own-vpn/index.html


### PR DESCRIPTION
## Summary
- add a Dockerfile for running the certificate tools inside a container
- ignore build artifacts with `.dockerignore`
- document Docker usage in the README

## Testing
- `python3 -m py_compile central/scripts/kdc.py && python3 -m py_compile central/scripts/key_manager.py`
